### PR TITLE
ci: trigger publish workflow on **version-update** branches

### DIFF
--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 'master'
+      - '**version-update**'
 jobs:
   build_project:
     runs-on: macos-latest


### PR DESCRIPTION
## Summary
- Adds `**version-update**` to the `branches` trigger list in `publish-new-version.yml` so any branch whose name contains `version-update` (e.g. `MMMX-12345-version-update`, `renovate/version-update`) kicks off the publish workflow.
- Previously the workflow only ran on `master` — meaning version bumps had to be merged before they could be published to Maven Central.

## Test plan
- [ ] Open a branch with `version-update` in the name and push a trivial change → confirm the `Publish new version` workflow starts.
- [ ] Push to `master` — confirm the workflow still runs as before.
- [ ] Push to a branch without `version-update` in its name — confirm the workflow does NOT run.