### PR TITLE
tech: [MMMX-55489]: fix TransactionTooLargeException when copying all logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ local.properties
 .kotlin
 **/Pods
 **/Podfile.lock
+**/*.podspec

--- a/logkmpanion/build.gradle.kts
+++ b/logkmpanion/build.gradle.kts
@@ -38,6 +38,9 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.activity.compose)
         }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
     }
 
     cocoapods {

--- a/logkmpanion/src/androidMain/AndroidManifest.xml
+++ b/logkmpanion/src/androidMain/AndroidManifest.xml
@@ -2,5 +2,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
         <activity android:name=".presentation.component.LogKMPanionActivity" />
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.logkmpanion.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/logkmpanion_file_paths" />
+        </provider>
     </application>
 </manifest>

--- a/logkmpanion/src/androidMain/kotlin/com/idfinance/logkmpanion/presentation/component/LogKMPanionActivity.kt
+++ b/logkmpanion/src/androidMain/kotlin/com/idfinance/logkmpanion/presentation/component/LogKMPanionActivity.kt
@@ -23,8 +23,11 @@ class LogKMPanionActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        ServiceLocator.logSharer = LogSharerImpl(applicationContext)
-        val root = ServiceLocator.getRootComponent(defaultComponentContext(), this::finish)
+        val root = ServiceLocator.getRootComponent(
+            context = defaultComponentContext(),
+            logSharer = LogSharerImpl(applicationContext),
+            onClose = this::finish,
+        )
         setContent {
             RootView(root)
         }

--- a/logkmpanion/src/androidMain/kotlin/com/idfinance/logkmpanion/presentation/component/LogKMPanionActivity.kt
+++ b/logkmpanion/src/androidMain/kotlin/com/idfinance/logkmpanion/presentation/component/LogKMPanionActivity.kt
@@ -33,3 +33,4 @@ class LogKMPanionActivity : ComponentActivity() {
         }
     }
 }
+

--- a/logkmpanion/src/androidMain/kotlin/com/idfinance/logkmpanion/presentation/component/LogKMPanionActivity.kt
+++ b/logkmpanion/src/androidMain/kotlin/com/idfinance/logkmpanion/presentation/component/LogKMPanionActivity.kt
@@ -6,8 +6,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.arkivanov.decompose.defaultComponentContext
-import com.idfinance.logkmpanion.presentation.ui.root.RootView
 import com.idfinance.logkmpanion.ServiceLocator
+import com.idfinance.logkmpanion.presentation.ui.allLogs.LogSharerImpl
+import com.idfinance.logkmpanion.presentation.ui.root.RootView
 
 fun openLogKMPanion(context: Context) {
     context.startActivity(
@@ -22,6 +23,7 @@ class LogKMPanionActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        ServiceLocator.logSharer = LogSharerImpl(applicationContext)
         val root = ServiceLocator.getRootComponent(defaultComponentContext(), this::finish)
         setContent {
             RootView(root)

--- a/logkmpanion/src/androidMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogSharer.kt
+++ b/logkmpanion/src/androidMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogSharer.kt
@@ -1,0 +1,29 @@
+package com.idfinance.logkmpanion.presentation.ui.allLogs
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+internal class LogSharerImpl(private val context: Context) : LogSharer {
+    override suspend fun shareAsFile(content: String, fileName: String) {
+        val uri = withContext(Dispatchers.Default) {
+            val file = File(context.cacheDir, fileName).apply { writeText(content) }
+            FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.logkmpanion.fileprovider",
+                file,
+            )
+        }
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(
+            Intent.createChooser(intent, null).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+        )
+    }
+}

--- a/logkmpanion/src/androidMain/res/xml/logkmpanion_file_paths.xml
+++ b/logkmpanion/src/androidMain/res/xml/logkmpanion_file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="logkmpanion_logs" path="." />
+</paths>

--- a/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/ServiceLocator.kt
+++ b/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/ServiceLocator.kt
@@ -17,6 +17,7 @@ import com.idfinance.logkmpanion.domain.usecase.SaveLogUseCase
 import com.idfinance.logkmpanion.domain.usecase.SaveRequestUseCase
 import com.idfinance.logkmpanion.domain.usecase.SaveResponseUseCase
 import com.idfinance.logkmpanion.presentation.ui.allLogs.DefaultAllLogsComponent
+import com.idfinance.logkmpanion.presentation.ui.allLogs.LogSharer
 import com.idfinance.logkmpanion.presentation.ui.networkLogs.DefaultNetworkLogsComponent
 import com.idfinance.logkmpanion.presentation.ui.networkLogs.details.DefaultNetworkLogDetailsComponent
 import com.idfinance.logkmpanion.presentation.ui.root.DefaultRootComponent
@@ -24,6 +25,8 @@ import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
 
 internal object ServiceLocator {
+
+    internal var logSharer: LogSharer? = null
 
     val saveLogUseCase: SaveLogUseCase
         get() = SaveLogUseCase(repository)
@@ -41,7 +44,12 @@ internal object ServiceLocator {
         DefaultRootComponent(context, onClose)
 
     fun getAllLogsComponent(context: ComponentContext) =
-        DefaultAllLogsComponent(context, getAllLogsFlowUseCase, clearLogsUseCase)
+        DefaultAllLogsComponent(
+            context,
+            getAllLogsFlowUseCase,
+            clearLogsUseCase,
+            checkNotNull(logSharer) { "Set ServiceLocator.logSharer before opening LogKMPanion" },
+        )
 
     fun getNetworkLogsComponent(context: ComponentContext) =
         DefaultNetworkLogsComponent(context, getNetworkLogsFlowUseCase, clearNetworkLogsUseCase)

--- a/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/ServiceLocator.kt
+++ b/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/ServiceLocator.kt
@@ -26,8 +26,6 @@ import io.realm.kotlin.RealmConfiguration
 
 internal object ServiceLocator {
 
-    internal var logSharer: LogSharer? = null
-
     val saveLogUseCase: SaveLogUseCase
         get() = SaveLogUseCase(repository)
 
@@ -40,15 +38,15 @@ internal object ServiceLocator {
     val saveErrorUseCase: SaveErrorUseCase
         get() = SaveErrorUseCase(repository)
 
-    fun getRootComponent(context: ComponentContext, onClose: () -> Unit) =
-        DefaultRootComponent(context, onClose)
+    fun getRootComponent(context: ComponentContext, logSharer: LogSharer, onClose: () -> Unit) =
+        DefaultRootComponent(context, logSharer, onClose)
 
-    fun getAllLogsComponent(context: ComponentContext) =
+    fun getAllLogsComponent(context: ComponentContext, logSharer: LogSharer) =
         DefaultAllLogsComponent(
             context,
             getAllLogsFlowUseCase,
             clearLogsUseCase,
-            checkNotNull(logSharer) { "Set ServiceLocator.logSharer before opening LogKMPanion" },
+            logSharer,
         )
 
     fun getNetworkLogsComponent(context: ComponentContext) =

--- a/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/AllLogsComponent.kt
+++ b/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/AllLogsComponent.kt
@@ -4,18 +4,15 @@ import com.arkivanov.decompose.value.Value
 import com.idfinance.logkmpanion.data.model.Log
 
 internal interface AllLogsComponent {
-    /**
-     *
-     */
     val model: Value<Model>
 
-    /**
-     *
-     */
     fun clearLogs()
+    fun shareFullLog()
 
     data class Model(val logs: List<Log> = emptyList()) {
-        val concatenatedLog: String
+        internal val full: String
             get() = logs.joinToString("\n") { "[${it.tag}] ${it.message}" }
+        val clipboardPayload: ClipboardPayload
+            get() = tailWithinByteLimit(full)
     }
 }

--- a/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/AllLogsView.kt
+++ b/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/AllLogsView.kt
@@ -35,6 +35,9 @@ import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.idfinance.logkmpanion.data.model.Log
+import com.idfinance.logkmpanion.domain.LogType
+import com.idfinance.logkmpanion.domain.addToLogKMPanion
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -102,7 +105,17 @@ private suspend fun copyLogsAndNotify(
     snackbarHostState: SnackbarHostState,
     onShareConfirmed: () -> Unit,
 ) {
-    runCatching { clipboardManager.setText(AnnotatedString(payload.text)) }
+    try {
+        clipboardManager.setText(AnnotatedString(payload.text))
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        addToLogKMPanion(
+            type = LogType.ERROR,
+            tag = "LogKMPanion",
+            message = "Failed to copy logs to clipboard: ${e.message ?: e::class.simpleName}",
+        )
+    }
     if (payload.wasTruncated) {
         val result = snackbarHostState.showSnackbar(
             message = "Copied last 512 KB. Share full log as file?",

--- a/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/AllLogsView.kt
+++ b/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/AllLogsView.kt
@@ -15,11 +15,18 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -28,6 +35,7 @@ import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.idfinance.logkmpanion.data.model.Log
+import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.ExperimentalTime
@@ -37,10 +45,14 @@ import kotlin.time.Instant
 internal fun AllLogsView(component: AllLogsComponent) {
     val model by component.model.subscribeAsState()
     val state = rememberLazyListState()
+    val snackbarHostState = remember { SnackbarHostState() }
     LaunchedEffect(model.logs.size) {
         state.animateScrollToItem(maxOf(model.logs.size - 1, 0))
     }
-    Scaffold(floatingActionButton = { FloatingActionButtons(component) }) {
+    Scaffold(
+        floatingActionButton = { FloatingActionButtons(component, snackbarHostState) },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) {
         LazyColumn(state = state, verticalArrangement = Arrangement.spacedBy(12.dp)) {
             itemsIndexed(model.logs) { index, it ->
                 Text(
@@ -61,18 +73,45 @@ internal fun AllLogsView(component: AllLogsComponent) {
 }
 
 @Composable
-private fun FloatingActionButtons(component: AllLogsComponent) {
+private fun FloatingActionButtons(component: AllLogsComponent, snackbarHostState: SnackbarHostState) {
     val model by component.model.subscribeAsState()
     val clipboardManager = LocalClipboardManager.current
-    Column(
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
+    val scope = rememberCoroutineScope()
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         FloatingActionButton(onClick = component::clearLogs) {
             Icon(Icons.Default.Delete, null)
         }
-        FloatingActionButton(onClick = { clipboardManager.setText(AnnotatedString(model.concatenatedLog)) }) {
+        FloatingActionButton(onClick = {
+            scope.launch {
+                copyLogsAndNotify(
+                    payload = model.clipboardPayload,
+                    clipboardManager = clipboardManager,
+                    snackbarHostState = snackbarHostState,
+                    onShareConfirmed = component::shareFullLog,
+                )
+            }
+        }) {
             Icon(Icons.Default.ContentCopy, null)
         }
+    }
+}
+
+private suspend fun copyLogsAndNotify(
+    payload: ClipboardPayload,
+    clipboardManager: ClipboardManager,
+    snackbarHostState: SnackbarHostState,
+    onShareConfirmed: () -> Unit,
+) {
+    runCatching { clipboardManager.setText(AnnotatedString(payload.text)) }
+    if (payload.wasTruncated) {
+        val result = snackbarHostState.showSnackbar(
+            message = "Copied last 512 KB. Share full log as file?",
+            actionLabel = "Share",
+            duration = SnackbarDuration.Long,
+        )
+        if (result == SnackbarResult.ActionPerformed) onShareConfirmed()
+    } else {
+        snackbarHostState.showSnackbar("Logs copied")
     }
 }
 

--- a/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/DefaultAllLogsComponent.kt
+++ b/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/DefaultAllLogsComponent.kt
@@ -10,12 +10,13 @@ import com.idfinance.logkmpanion.domain.addToLogKMPanion
 import com.idfinance.logkmpanion.domain.usecase.ClearLogsUseCase
 import com.idfinance.logkmpanion.domain.usecase.GetAllLogsFlowUseCase
 import com.idfinance.logkmpanion.presentation.extensions.disposableScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
+import kotlinx.coroutines.withContext
 
 internal class DefaultAllLogsComponent(
     context: ComponentContext,
@@ -48,17 +49,18 @@ internal class DefaultAllLogsComponent(
         launch { clearLogsUseCase() }
     }
 
-    @OptIn(ExperimentalTime::class)
     override fun shareFullLog() {
         launch {
-            runCatching {
-                val timestamp = Clock.System.now().epochSeconds
-                logSharer.shareAsFile(_model.value.full, "logkmpanion-$timestamp.txt")
-            }.onFailure { error ->
+            try {
+                val content = withContext(Dispatchers.Default) { _model.value.full }
+                logSharer.shareAsFile(content, "logkmpanion-logs.txt")
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
                 addToLogKMPanion(
                     type = LogType.ERROR,
                     tag = "LogKMPanion",
-                    message = "Failed to share log file: ${error.message ?: error::class.simpleName}",
+                    message = "Failed to share log file: ${e.message ?: e::class.simpleName}",
                 )
             }
         }

--- a/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/DefaultAllLogsComponent.kt
+++ b/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/DefaultAllLogsComponent.kt
@@ -5,6 +5,8 @@ import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
 import com.arkivanov.essenty.lifecycle.doOnStart
 import com.arkivanov.essenty.lifecycle.doOnStop
+import com.idfinance.logkmpanion.domain.LogType
+import com.idfinance.logkmpanion.domain.addToLogKMPanion
 import com.idfinance.logkmpanion.domain.usecase.ClearLogsUseCase
 import com.idfinance.logkmpanion.domain.usecase.GetAllLogsFlowUseCase
 import com.idfinance.logkmpanion.presentation.extensions.disposableScope
@@ -12,11 +14,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 internal class DefaultAllLogsComponent(
     context: ComponentContext,
     getAllLogsFlowUseCase: GetAllLogsFlowUseCase,
-    private val clearLogsUseCase: ClearLogsUseCase
+    private val clearLogsUseCase: ClearLogsUseCase,
+    private val logSharer: LogSharer,
 ) : AllLogsComponent,
     ComponentContext by context,
     CoroutineScope by context.disposableScope() {
@@ -41,5 +46,21 @@ internal class DefaultAllLogsComponent(
 
     override fun clearLogs() {
         launch { clearLogsUseCase() }
+    }
+
+    @OptIn(ExperimentalTime::class)
+    override fun shareFullLog() {
+        launch {
+            runCatching {
+                val timestamp = Clock.System.now().epochSeconds
+                logSharer.shareAsFile(_model.value.full, "logkmpanion-$timestamp.txt")
+            }.onFailure { error ->
+                addToLogKMPanion(
+                    type = LogType.ERROR,
+                    tag = "LogKMPanion",
+                    message = "Failed to share log file: ${error.message ?: error::class.simpleName}",
+                )
+            }
+        }
     }
 }

--- a/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogClipboard.kt
+++ b/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogClipboard.kt
@@ -7,8 +7,13 @@ internal data class ClipboardPayload(val text: String, val wasTruncated: Boolean
 internal fun tailWithinByteLimit(text: String, maxBytes: Int = CLIPBOARD_MAX_BYTES): ClipboardPayload {
     val bytes = text.encodeToByteArray()
     if (bytes.size <= maxBytes) return ClipboardPayload(text, false)
-    val tail = bytes.copyOfRange(bytes.size - maxBytes, bytes.size)
-    val tailStr = tail.decodeToString(throwOnInvalidSequence = false)
-    val cleanStart = tailStr.indexOf('\n').let { if (it >= 0) it + 1 else 0 }
-    return ClipboardPayload(tailStr.substring(cleanStart), true)
+
+    // Skip UTF-8 continuation bytes (10xxxxxx) so we don't start mid-codepoint.
+    var start = bytes.size - maxBytes
+    while (start < bytes.size && (bytes[start].toInt() and 0xC0) == 0x80) start++
+
+    val tail = bytes.copyOfRange(start, bytes.size).decodeToString()
+    val firstNewline = tail.indexOf('\n')
+    val result = if (firstNewline >= 0) tail.substring(firstNewline + 1) else tail
+    return ClipboardPayload(result, true)
 }

--- a/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogClipboard.kt
+++ b/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogClipboard.kt
@@ -1,0 +1,14 @@
+package com.idfinance.logkmpanion.presentation.ui.allLogs
+
+internal const val CLIPBOARD_MAX_BYTES = 512 * 1024
+
+internal data class ClipboardPayload(val text: String, val wasTruncated: Boolean)
+
+internal fun tailWithinByteLimit(text: String, maxBytes: Int = CLIPBOARD_MAX_BYTES): ClipboardPayload {
+    val bytes = text.encodeToByteArray()
+    if (bytes.size <= maxBytes) return ClipboardPayload(text, false)
+    val tail = bytes.copyOfRange(bytes.size - maxBytes, bytes.size)
+    val tailStr = tail.decodeToString(throwOnInvalidSequence = false)
+    val cleanStart = tailStr.indexOf('\n').let { if (it >= 0) it + 1 else 0 }
+    return ClipboardPayload(tailStr.substring(cleanStart), true)
+}

--- a/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogSharer.kt
+++ b/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogSharer.kt
@@ -1,0 +1,5 @@
+package com.idfinance.logkmpanion.presentation.ui.allLogs
+
+internal interface LogSharer {
+    suspend fun shareAsFile(content: String, fileName: String)
+}

--- a/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/root/DefaultRootComponent.kt
+++ b/logkmpanion/src/commonMain/kotlin/com/idfinance/logkmpanion/presentation/ui/root/DefaultRootComponent.kt
@@ -8,11 +8,13 @@ import com.arkivanov.decompose.router.stack.replaceAll
 import com.arkivanov.decompose.value.Value
 import com.idfinance.logkmpanion.ServiceLocator
 import com.idfinance.logkmpanion.presentation.extensions.disposableScope
+import com.idfinance.logkmpanion.presentation.ui.allLogs.LogSharer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.Serializable
 
 internal class DefaultRootComponent(
     context: ComponentContext,
+    private val logSharer: LogSharer,
     private val onClose: () -> Unit,
 ) : RootComponent,
     ComponentContext by context,
@@ -27,7 +29,7 @@ internal class DefaultRootComponent(
         childFactory = { config, context ->
             when (config) {
                 Config.AllLogs -> {
-                    val component = ServiceLocator.getAllLogsComponent(context)
+                    val component = ServiceLocator.getAllLogsComponent(context, logSharer)
                     RootComponent.Child.AllLogs(component)
                 }
 

--- a/logkmpanion/src/commonTest/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogClipboardTest.kt
+++ b/logkmpanion/src/commonTest/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogClipboardTest.kt
@@ -1,0 +1,72 @@
+package com.idfinance.logkmpanion.presentation.ui.allLogs
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LogClipboardTest {
+
+    @Test
+    fun emptyInput_returnsEmpty_notTruncated() {
+        val result = tailWithinByteLimit("")
+        assertEquals(ClipboardPayload("", false), result)
+    }
+
+    @Test
+    fun underLimit_returnsOriginal_notTruncated() {
+        val text = "hi"
+        val result = tailWithinByteLimit(text, maxBytes = 100)
+        assertEquals(ClipboardPayload(text, false), result)
+    }
+
+    @Test
+    fun exactlyAtLimit_returnsOriginal_notTruncated() {
+        val text = "a".repeat(100)
+        val result = tailWithinByteLimit(text, maxBytes = 100)
+        assertEquals(ClipboardPayload(text, false), result)
+    }
+
+    @Test
+    fun overLimitWithNewline_dropsPartialFirstLine_marksTruncated() {
+        val text = "line1\n" + "x".repeat(200)
+        val result = tailWithinByteLimit(text, maxBytes = 100)
+        assertTrue(result.wasTruncated)
+        // first line ("line1") was beyond the cut and gets discarded
+        assertFalse(result.text.startsWith("line1"))
+        // result starts cleanly with the surviving content
+        assertEquals("x".repeat(100), result.text)
+    }
+
+    @Test
+    fun overLimitWithoutNewline_returnsTail_marksTruncated() {
+        val text = "x".repeat(200)
+        val result = tailWithinByteLimit(text, maxBytes = 100)
+        assertTrue(result.wasTruncated)
+        assertEquals(100, result.text.length)
+        // pure ASCII tail, no replacement chars
+        assertFalse(result.text.contains('�'))
+    }
+
+    @Test
+    fun multibyteUtf8OnBoundary_skipsContinuationBytes_noReplacementChars() {
+        // "ä" = 2 UTF-8 bytes (0xC3 0xA4). With maxBytes = 100, we want the cut
+        // to land mid-codepoint so the continuation-byte skip logic kicks in.
+        val text = "a".repeat(50) + "ä".repeat(50) + "tail"
+        val result = tailWithinByteLimit(text, maxBytes = 100)
+        assertTrue(result.wasTruncated)
+        // continuation-byte skip ensures we never start with a replacement char
+        assertFalse(result.text.contains('�'), "unexpected replacement char in: ${result.text}")
+        // and the tail is preserved
+        assertTrue(result.text.endsWith("tail"))
+    }
+
+    @Test
+    fun multibyteUtf8WithNewline_dropsBrokenPrefix() {
+        // Force a multibyte split, but include a newline so the partial-line trim runs too.
+        val text = "ä".repeat(60) + "\nrest"
+        val result = tailWithinByteLimit(text, maxBytes = 50)
+        assertTrue(result.wasTruncated)
+        assertEquals("rest", result.text)
+    }
+}

--- a/logkmpanion/src/iosMain/kotlin/com/idfinance/logkmpanion/presentation/DebugViewViewController.kt
+++ b/logkmpanion/src/iosMain/kotlin/com/idfinance/logkmpanion/presentation/DebugViewViewController.kt
@@ -19,10 +19,11 @@ fun LogKMPanionViewControllerProvider(onClose: () -> Unit): UIViewController =
 @OptIn(ExperimentalForeignApi::class)
 private class LogKMPanionViewController(onClose: () -> Unit) : UIViewController(null, null) {
     private val lifecycle = LifecycleRegistry()
-    private val component = run {
-        ServiceLocator.logSharer = LogSharerImpl()
-        ServiceLocator.getRootComponent(DefaultComponentContext(lifecycle), onClose)
-    }
+    private val component = ServiceLocator.getRootComponent(
+        context = DefaultComponentContext(lifecycle),
+        logSharer = LogSharerImpl(this),
+        onClose = onClose,
+    )
     private val controller = ComposeDebugViewViewController(component)
 
     override fun viewDidLoad() {

--- a/logkmpanion/src/iosMain/kotlin/com/idfinance/logkmpanion/presentation/DebugViewViewController.kt
+++ b/logkmpanion/src/iosMain/kotlin/com/idfinance/logkmpanion/presentation/DebugViewViewController.kt
@@ -5,6 +5,7 @@ import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.start
 import com.arkivanov.essenty.lifecycle.stop
 import com.idfinance.logkmpanion.ServiceLocator
+import com.idfinance.logkmpanion.presentation.ui.allLogs.LogSharerImpl
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.UIKit.UIViewController
 import platform.UIKit.addChildViewController
@@ -18,8 +19,10 @@ fun LogKMPanionViewControllerProvider(onClose: () -> Unit): UIViewController =
 @OptIn(ExperimentalForeignApi::class)
 private class LogKMPanionViewController(onClose: () -> Unit) : UIViewController(null, null) {
     private val lifecycle = LifecycleRegistry()
-    private val component =
+    private val component = run {
+        ServiceLocator.logSharer = LogSharerImpl()
         ServiceLocator.getRootComponent(DefaultComponentContext(lifecycle), onClose)
+    }
     private val controller = ComposeDebugViewViewController(component)
 
     override fun viewDidLoad() {

--- a/logkmpanion/src/iosMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogSharer.kt
+++ b/logkmpanion/src/iosMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogSharer.kt
@@ -12,9 +12,9 @@ import platform.Foundation.NSURL
 import platform.Foundation.create
 import platform.Foundation.writeToFile
 import platform.UIKit.UIActivityViewController
-import platform.UIKit.UIApplication
+import platform.UIKit.UIViewController
 
-internal class LogSharerImpl : LogSharer {
+internal class LogSharerImpl(private val host: UIViewController) : LogSharer {
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     override suspend fun shareAsFile(content: String, fileName: String) {
         val path = withContext(Dispatchers.Default) {
@@ -29,9 +29,7 @@ internal class LogSharerImpl : LogSharer {
         withContext(Dispatchers.Main) {
             val url = NSURL.fileURLWithPath(path)
             val vc = UIActivityViewController(activityItems = listOf(url), applicationActivities = null)
-            UIApplication.sharedApplication.keyWindow?.rootViewController?.presentViewController(
-                vc, animated = true, completion = null,
-            )
+            host.presentViewController(vc, animated = true, completion = null)
         }
     }
 }

--- a/logkmpanion/src/iosMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogSharer.kt
+++ b/logkmpanion/src/iosMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogSharer.kt
@@ -1,0 +1,37 @@
+package com.idfinance.logkmpanion.presentation.ui.allLogs
+
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import platform.Foundation.NSData
+import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSURL
+import platform.Foundation.create
+import platform.Foundation.writeToFile
+import platform.UIKit.UIActivityViewController
+import platform.UIKit.UIApplication
+
+internal class LogSharerImpl : LogSharer {
+    @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+    override suspend fun shareAsFile(content: String, fileName: String) {
+        val path = withContext(Dispatchers.Default) {
+            val p = NSTemporaryDirectory() + fileName
+            val bytes = content.encodeToByteArray()
+            bytes.usePinned { pinned ->
+                NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
+                    .writeToFile(p, atomically = true)
+            }
+            p
+        }
+        withContext(Dispatchers.Main) {
+            val url = NSURL.fileURLWithPath(path)
+            val vc = UIActivityViewController(activityItems = listOf(url), applicationActivities = null)
+            UIApplication.sharedApplication.keyWindow?.rootViewController?.presentViewController(
+                vc, animated = true, completion = null,
+            )
+        }
+    }
+}


### PR DESCRIPTION
Fixes [MMMX-55489](https://plazo-idf.atlassian.net/browse/MMMX-55489), closes #59.

## What changed

Copy FAB no longer pushes the entire log buffer through the Android Binder.

- **≤ 512 KB** → goes to clipboard as before, snackbar "Logs copied".
- **> 512 KB** → tail (cut by `\n`) goes to clipboard, snackbar "Copied last 512 KB. Share full log as file?" with a `Share` action that writes the full log to `cacheDir`/`NSTemporaryDirectory` and opens the system share-sheet (`FileProvider` + `ACTION_SEND` on Android, `UIActivityViewController` on iOS).
- Both clipboard write and share path wrapped in `runCatching`; share failures are logged back into the same buffer as `LogType.ERROR`.

## Key files

- `LogClipboard.kt` — `tailWithinByteLimit(text, 512 KB)` helper.
- `LogSharer` (interface) + `LogSharerImpl` per platform — `suspend shareAsFile`, file write on `Dispatchers.Default`, UIKit calls on `Dispatchers.Main`.
- `AllLogsComponent.shareFullLog()` — new action.
- `AndroidManifest.xml` + `res/xml/logkmpanion_file_paths.xml` — FileProvider.

## Test plan

- [x] Generate ~5 MB of logs → copy → no crash, truncated snackbar, Share opens chooser.
- [x] Small log → "Logs copied" snackbar, no share path.
- [x] Force share failure → red error row appears in the log view, no crash.



https://github.com/user-attachments/assets/64bfd084-fe13-4777-a0bc-7af94340e1c6

https://github.com/user-attachments/assets/172abcd9-2413-4455-880c-6f1896b63a34


