### PR TITLE
fix: subclass FileProvider to avoid manifest-merge authority collision

### DIFF
--- a/logkmpanion/src/androidMain/AndroidManifest.xml
+++ b/logkmpanion/src/androidMain/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <application>
         <activity android:name=".presentation.component.LogKMPanionActivity" />
         <provider
-            android:name="androidx.core.content.FileProvider"
+            android:name=".presentation.ui.allLogs.LogKMPanionFileProvider"
             android:authorities="${applicationId}.logkmpanion.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/logkmpanion/src/androidMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogKMPanionFileProvider.kt
+++ b/logkmpanion/src/androidMain/kotlin/com/idfinance/logkmpanion/presentation/ui/allLogs/LogKMPanionFileProvider.kt
@@ -1,0 +1,16 @@
+package com.idfinance.logkmpanion.presentation.ui.allLogs
+
+import androidx.core.content.FileProvider
+
+/**
+ * Dedicated [FileProvider] subclass with a unique class name.
+ *
+ * The Android manifest merger keys `<provider>` elements by `android:name`. Consumer apps
+ * (especially Flutter ones) almost always bundle other libraries that declare their own
+ * `androidx.core.content.FileProvider`, so a bare declaration would collide on the class name
+ * and our authority + path meta-data would be dropped from the merged manifest — leading to
+ * `IllegalArgumentException: Couldn't find meta-data for provider with authority ...` at runtime.
+ *
+ * Subclassing gives us a unique `android:name`, so our provider survives the merge intact.
+ */
+internal class LogKMPanionFileProvider : FileProvider()


### PR DESCRIPTION
The provider was declared with android:name="androidx.core.content.FileProvider". The manifest merger keys <provider> by android:name, so in consumer apps that bundle other FileProvider-declaring libraries (e.g. Flutter plugins: share_plus, file_picker, flutter_email_sender), our entry collided on the class name and our authority + path meta-data were dropped from the merged manifest. At runtime getUriForFile then threw "Couldn't find meta-data for provider with authority ...logkmpanion.fileprovider".

Subclassing FileProvider gives a unique android:name so our provider survives the merge intact — the same approach every other FileProvider library in those apps already uses.